### PR TITLE
Specify import type / export type

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,1 +1,2 @@
-export { Cache, CacheOptions, CacheProperties } from "./src/cache.ts";
+export { Cache } from "./src/cache.ts";
+export type { CacheOptions, CacheProperties } from "./src/cache.ts";

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,5 +1,5 @@
-import { State, Identifier, Nullable } from "./util.ts";
-import { CacheOptions } from "./cache.ts";
+import type { State, Identifier, Nullable } from "./util.ts";
+import type { CacheOptions } from "./cache.ts";
 
 const decoder = new TextDecoder("utf-8");
 


### PR DESCRIPTION
Fixes errors with deno 1.40 and --unstable flag

With the release of Deno 1.4.0, there have changes to typescript flags that breaks library that are not explicit when importing / exporting types

```
error: TS1371 [ERROR]: This import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.
import { State, Identifier, Nullable } from "./util.ts";
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    at https://deno.land/x/dash@2.2.2/src/state.ts:1:1

TS1371 [ERROR]: This import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.
import { CacheOptions } from "./cache.ts";
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    at https://deno.land/x/dash@2.2.2/src/state.ts:2:1

TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
export { Cache, CacheOptions, CacheProperties } from "./src/cache.ts";
                ~~~~~~~~~~~~
    at https://deno.land/x/dash@2.2.2/mod.ts:1:17

TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
export { Cache, CacheOptions, CacheProperties } from "./src/cache.ts";
                              ~~~~~~~~~~~~~~~
    at https://deno.land/x/dash@2.2.2/mod.ts:1:31
```